### PR TITLE
refactored to use typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const { resolve } = require("path");
+
 module.exports = {
   // https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy
   // This option interrupts the configuration hierarchy at this file
@@ -5,13 +7,21 @@ module.exports = {
   root: true,
 
   parserOptions: {
-    parser: '@babel/eslint-parser',
+    // JavaScript
+    // parser: "@babel/eslint-parser",
+    // ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+    // sourceType: "module", // Allows for the use of imports
+    // Typescript
+    extraFileExtensions: [".vue"],
+    parser: "@typescript-eslint/parser",
+    project: resolve(__dirname, "./tsconfig.json"),
+    tsconfigRootDir: __dirname,
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
-    sourceType: 'module' // Allows for the use of imports
+    sourceType: "module", // Allows for the use of imports
   },
 
   env: {
-    browser: true
+    browser: true,
   },
 
   // Rules order is important, please avoid shuffling them
@@ -19,23 +29,25 @@ module.exports = {
     // Base ESLint recommended rules
     // 'eslint:recommended',
 
-
     // Uncomment any of the lines below to choose desired strictness,
     // but leave only one uncommented!
     // See https://eslint.vuejs.org/rules/#available-rules
-    'plugin:vue/vue3-essential', // Priority A: Essential (Error Prevention)
-    // 'plugin:vue/vue3-strongly-recommended', // Priority B: Strongly Recommended (Improving Readability)
+    "plugin:vue/vue3-essential", // Priority A: Essential (Error Prevention)
+    "plugin:vue/vue3-strongly-recommended", // Priority B: Strongly Recommended (Improving Readability)
     // 'plugin:vue/vue3-recommended', // Priority C: Recommended (Minimizing Arbitrary Choices and Cognitive Overhead)
 
     // https://github.com/prettier/eslint-config-prettier#installation
     // usage with Prettier, provided by 'eslint-config-prettier'.
-    'prettier'
+    "prettier",
   ],
 
   plugins: [
+    // required to apply rules which need type information
+    "@typescript-eslint",
+
     // https://eslint.vuejs.org/user-guide/#why-doesn-t-it-work-on-vue-file
     // required to lint *.vue files
-    'vue',
+    "vue",
 
     // https://github.com/typescript-eslint/typescript-eslint/issues/389#issuecomment-509292674
     // Prettier has not been included as plugin to avoid performance impact
@@ -43,24 +55,25 @@ module.exports = {
   ],
 
   globals: {
-    ga: 'readonly', // Google Analytics
-    cordova: 'readonly',
-    __statics: 'readonly',
-    __QUASAR_SSR__: 'readonly',
-    __QUASAR_SSR_SERVER__: 'readonly',
-    __QUASAR_SSR_CLIENT__: 'readonly',
-    __QUASAR_SSR_PWA__: 'readonly',
-    process: 'readonly',
-    Capacitor: 'readonly',
-    chrome: 'readonly'
+    ga: "readonly", // Google Analytics
+    cordova: "readonly",
+    __statics: "readonly",
+    __QUASAR_SSR__: "readonly",
+    __QUASAR_SSR_SERVER__: "readonly",
+    __QUASAR_SSR_CLIENT__: "readonly",
+    __QUASAR_SSR_PWA__: "readonly",
+    process: "readonly",
+    Capacitor: "readonly",
+    chrome: "readonly",
   },
 
   // add your custom rules here
   rules: {
-    'prefer-promise-reject-errors': 'off',
-
+    "prefer-promise-reject-errors": "off",
 
     // allow debugger during development only
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
-  }
-}
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
+    // TypeScript
+    "@typescript-eslint/explicit-function-return-type": "off",
+  },
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,11 @@
   "vetur.validation.template": false,
   "vetur.format.enable": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "vue"],
-  
+
   "vetur.experimental.templateInterpolationService": true,
   "git.enableCommitSigning": true,
   "editor.formatOnSave": true,
   "[javascript]": {
-      "editor.formatOnSave": true
-  }  
+    "editor.formatOnSave": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.13.14",
     "@quasar/app": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.31.2",
+    "@typescript-eslint/parser": "^4.31.2",
     "connect-history-api-fallback": "1.6.0",
-    "eslint": "^7.14.0",
+    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-vue": "^7.0.0",
     "eslint-webpack-plugin": "^2.4.0",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -13,7 +13,7 @@ const { configure } = require("quasar/wrappers");
 module.exports = configure(function (ctx) {
   return {
     // https://v2.quasar.dev/quasar-cli/supporting-ts
-    supportTS: false,
+    supportTS: true,
 
     // https://v2.quasar.dev/quasar-cli/prefetch-feature
     // preFetch: true,

--- a/src/aws/ssm/delete.ts
+++ b/src/aws/ssm/delete.ts
@@ -1,3 +1,5 @@
+import { DeleteParameterCommandInput } from "@aws-sdk/client-ssm";
+
 const { SSMClient, DeleteParametersCommand } = require("@aws-sdk/client-ssm"); // CommonJS import
 
 const client = new SSMClient({
@@ -11,7 +13,9 @@ const client = new SSMClient({
   endpoint: "http://localhost:4566",
 });
 
-export async function ssmDeleteParametersByNames(params) {
+export async function ssmDeleteParametersByNames(
+  params: DeleteParameterCommandInput
+) {
   const command = new DeleteParametersCommand(params);
   const response = await client.send(command);
   return response;

--- a/src/aws/ssm/get.ts
+++ b/src/aws/ssm/get.ts
@@ -1,3 +1,8 @@
+import {
+  GetParameterCommandInput,
+  GetParameterHistoryCommandInput,
+} from "@aws-sdk/client-ssm";
+
 const {
   SSMClient,
   GetParameterCommand,
@@ -21,7 +26,7 @@ const paginatorConfig = {
   pageSize: 10, // Max items per API call is 10 - https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html
 };
 
-export async function ssmGetParametersByPath(params) {
+export async function ssmGetParametersByPath(params: GetParameterCommandInput) {
   const parametersList = [];
   for await (const page of paginateGetParametersByPath(
     paginatorConfig,
@@ -35,7 +40,10 @@ export async function ssmGetParametersByPath(params) {
   };
 }
 
-export async function ssmGetParameterByName(name, withDecryption) {
+export async function ssmGetParameterByName(
+  name: String,
+  withDecryption: Boolean
+) {
   const command = GetParameterCommand({
     Name: name,
     WithDecryption: withDecryption,
@@ -43,7 +51,9 @@ export async function ssmGetParameterByName(name, withDecryption) {
   return await client.send(command);
 }
 
-export async function ssmGetParameterHistory(params) {
+export async function ssmGetParameterHistory(
+  params: GetParameterHistoryCommandInput
+) {
   const parameterHistoryList = [];
   for await (const page of paginateGetParameterHistory(
     paginatorConfig,

--- a/src/aws/ssm/set.ts
+++ b/src/aws/ssm/set.ts
@@ -1,4 +1,10 @@
-const { SSMClient, PutParameterCommand } = require("@aws-sdk/client-ssm"); // CommonJS import
+import { PutParameterCommandInput } from "@aws-sdk/client-ssm";
+
+const {
+  SSMClient,
+  PutParameterCommand,
+  PutParameterRequest,
+} = require("@aws-sdk/client-ssm"); // CommonJS import
 
 const client = new SSMClient({
   apiVersion: "2014-11-06",
@@ -11,7 +17,7 @@ const client = new SSMClient({
   endpoint: "http://localhost:4566",
 });
 
-export async function ssmSetParameter(params) {
+export async function ssmSetParameter(params: PutParameterCommandInput) {
   const command = new PutParameterCommand(params);
   const response = await client.send(command);
   return response;

--- a/src/layouts/ServiceLayout.vue
+++ b/src/layouts/ServiceLayout.vue
@@ -11,7 +11,10 @@
 export default {
   name: "ServicePage",
   props: {
-    title: String,
+    title: {
+      type: String,
+      default: "",
+    },
   },
   data: function () {
     return {};

--- a/src/layouts/TableLayout.vue
+++ b/src/layouts/TableLayout.vue
@@ -11,7 +11,7 @@
       :selected-rows-label="getSelectedString"
       selection="multiple"
     >
-      <template v-slot:top>
+      <template #top>
         <div class="q-gutter-y-md column" style="max-width: 300px">
           <q-input
             bottom-slots
@@ -21,7 +21,7 @@
             v-model="queryString"
             label="Query String"
           >
-            <template v-slot:append>
+            <template #append>
               <q-icon
                 v-if="filter !== ''"
                 name="close"
@@ -39,7 +39,7 @@
             :color="color"
             v-model="filter"
           >
-            <template v-slot:append>
+            <template #append>
               <q-icon
                 v-if="filter !== ''"
                 name="close"
@@ -50,7 +50,7 @@
             </template>
           </q-input>
           <div class="row">
-            <router-link :to="{ name: 'create' }" custom v-slot:default="props">
+            <router-link :to="{ name: 'create' }" custom v-slot="props">
               <q-btn
                 class="column q-mr-md"
                 color="primary"
@@ -75,7 +75,7 @@
       <template
         v-for="(item, i) in headerCellSlots"
         :key="item + i"
-        v-slot:[item]="props"
+        #[item]="props"
       >
         <q-th :props="props">
           <q-icon name="edit" size="1.6em" class="q-pa-xs" />
@@ -89,7 +89,7 @@
           {{ props.col.label }}
         </q-th>
       </template>
-      <template v-slot:body="props">
+      <template #body="props">
         <q-tr :props="props">
           <q-td>
             <!-- Fixes `selected` issue where the checkboxes are corrupted -->
@@ -286,12 +286,27 @@ export default {
       type: Array[Object],
       default: [],
     },
-    rowKey: String,
+    rowKey: {
+      type: String,
+      default: "",
+    },
     // Functions
-    deleteItems: Function,
-    setItem: Function,
-    getItems: Function,
-    getItem: Function,
+    deleteItems: {
+      type: Function,
+      default: () => {},
+    },
+    setItem: {
+      type: Function,
+      default: () => {},
+    },
+    getItems: {
+      type: Function,
+      default: () => {},
+    },
+    getItem: {
+      type: Function,
+      default: () => {},
+    },
   },
   watch: {
     editItem: function (v, ov) {

--- a/src/pages/CreatePage.vue
+++ b/src/pages/CreatePage.vue
@@ -9,7 +9,10 @@ import { defineComponent } from "vue";
 
 export default defineComponent({
   props: {
-    title: String,
+    title: {
+      type: String,
+      default: "",
+    },
   },
   name: "CreatePage",
 });

--- a/src/pages/ServicesPage.vue
+++ b/src/pages/ServicesPage.vue
@@ -16,11 +16,7 @@
         <q-separator />
 
         <q-card-actions align="right">
-          <router-link
-            :to="{ name: 'ssm-parameters' }"
-            custom
-            v-slot:default="props"
-          >
+          <router-link :to="{ name: 'ssm-parameters' }" custom v-slot="props">
             <q-btn
               flat
               class="column q-mr-md"
@@ -29,7 +25,7 @@
               v-bind="linkProps(props)"
             />
           </router-link>
-          <router-link :to="{ name: 'create' }" custom v-slot:default="props">
+          <router-link :to="{ name: 'create' }" custom v-slot="props">
             <q-btn
               flat
               class="column q-mr-md"
@@ -70,7 +66,10 @@ export default {
     },
   },
   props: {
-    title: String,
+    title: {
+      type: String,
+      default: "",
+    },
   },
   data: function () {
     return {};

--- a/src/pages/SsmParameters.vue
+++ b/src/pages/SsmParameters.vue
@@ -3,11 +3,11 @@
     <table-layout
       :keys="keys"
       :items="items"
-      :deleteItems="deleteItems"
-      :getItem="getItem"
-      :setItem="setItem"
-      :getItems="getItems"
-      :rowKey="rowKey"
+      :delete-items="deleteItems"
+      :get-item="getItem"
+      :set-item="setItem"
+      :get-items="getItems"
+      :row-key="rowKey"
     />
   </q-page>
 </template>
@@ -49,6 +49,15 @@ export default {
           editable: {
             type: "select",
             data: ["String", "SecureString", "StringList"],
+          },
+        },
+        {
+          name: "Description",
+          field: "Description",
+          label: "Description",
+          sortable: false,
+          editable: {
+            type: "textarea",
           },
         },
         {
@@ -116,6 +125,7 @@ export default {
           Value: item.Value,
           Type: item.Type,
           Overwrite: true,
+          Description: item.Description,
         };
         params[item._changedProperty] = v;
         console.log("setItem params:", params);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@quasar/app/tsconfig-preset",
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,7 +1853,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
+"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -1961,6 +1961,75 @@
     "@types/webpack-sources" "*"
     anymatch "^3.0.0"
     source-map "^0.6.0"
+
+"@typescript-eslint/eslint-plugin@^4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.2.tgz#9f41efaee32cdab7ace94b15bd19b756dd099b0a"
+  integrity sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.31.2"
+    "@typescript-eslint/scope-manager" "4.31.2"
+    debug "^4.3.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.2.tgz#98727a9c1e977dd5d20c8705e69cd3c2a86553fa"
+  integrity sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.31.2"
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/typescript-estree" "4.31.2"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/parser@^4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.2.tgz#54aa75986e3302d91eff2bbbaa6ecfa8084e9c34"
+  integrity sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.31.2"
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/typescript-estree" "4.31.2"
+    debug "^4.3.1"
+
+"@typescript-eslint/scope-manager@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz#1d528cb3ed3bcd88019c20a57c18b897b073923a"
+  integrity sha512-2JGwudpFoR/3Czq6mPpE8zBPYdHWFGL6lUNIGolbKQeSNv4EAiHaR5GVDQaLA0FwgcdcMtRk+SBJbFGL7+La5w==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/visitor-keys" "4.31.2"
+
+"@typescript-eslint/types@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.2.tgz#2aea7177d6d744521a168ed4668eddbd912dfadf"
+  integrity sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==
+
+"@typescript-eslint/typescript-estree@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.2.tgz#abfd50594d8056b37e7428df3b2d185ef2d0060c"
+  integrity sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/visitor-keys" "4.31.2"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz#7d5b4a4705db7fe59ecffb273c1d082760f635cc"
+  integrity sha512-PrBId7EQq2Nibns7dd/ch6S6/M4/iwLM9McbgeEbCXfxdwRUNxJ4UNreJ6Gh3fI2GNKNrWnQxKL7oCPmngKBug==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    eslint-visitor-keys "^2.0.0"
 
 "@vue/compiler-core@3.2.4":
   version "3.2.4"
@@ -3145,7 +3214,7 @@ debug@^3.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -3521,6 +3590,13 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
@@ -3543,7 +3619,7 @@ eslint-webpack-plugin@^2.4.0:
     normalize-path "^3.0.0"
     schema-utils "^3.0.0"
 
-eslint@^7.14.0:
+eslint@^7.32.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
@@ -6754,7 +6830,7 @@ ts-loader@8.0.17:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
-tslib@^1.11.1:
+tslib@^1.11.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -6768,6 +6844,13 @@ tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
- Added TypeScript support for `.ts` and `.vue` files. I'm still using `.js` for `router/index.js` and `router/routes.js`. Adding TypeScript allows using existing Interfaces that were declared in AWS SDK, which makes the whole typing process easier.
- Linted all files after adding TypeScript